### PR TITLE
Resolve `gem build` warnings and bump version

### DIFF
--- a/lib/music_theory/version.rb
+++ b/lib/music_theory/version.rb
@@ -1,3 +1,3 @@
 module MusicTheory
-  VERSION = "0.3.2"
+  VERSION = "0.3.3"
 end

--- a/music_theory.gemspec
+++ b/music_theory.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["beneggett@gmail.com"]
   spec.summary       = %q{Music theory with ruby}
   spec.description   = %q{Create music with pure ruby goodness}
-  spec.homepage      = ""
+  spec.homepage      = "http://www.beneggett.com/#/ben-eggett"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")
@@ -18,9 +18,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "wavefile"
+  spec.add_runtime_dependency "wavefile", "~> 0"
 
-  spec.add_development_dependency "pry"
+  spec.add_development_dependency "pry", "~> 0"
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
Bumping version to 0.3.3 because of the removal of ActiveSupport dependency.

Resolving the following warnings from `gem build`

```
  WARNING:  open-ended dependency on wavefile (>= 0) is not recommended
    if wavefile is semantically versioned, use:
      add_runtime_dependency 'wavefile', '~> 0'
  WARNING:  open-ended dependency on pry (>= 0, development) is not recommended
    if pry is semantically versioned, use:
      add_development_dependency 'pry', '~> 0'
  WARNING:  See http://guides.rubygems.org/specification-reference/ for help
    Successfully built RubyGem
    Name: music_theory
    Version: 0.3.2
    File: music_theory-0.3.2.gem
```
